### PR TITLE
update to fix eject bug, add state signals, add erase mode

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -96,6 +96,13 @@ data:extend{
     subgroup = "virtual-signal-diskreader",
     order = "z[diskreader]-[W]"
   },
+  {
+    type = "virtual-signal",
+    name = "signal-diskreader-status",
+    icon = "__base__/graphics/icons/signal/signal_S.png",
+    subgroup = "virtual-signal-diskreader",
+    order = "z[diskreader]-[S]"
+  },
 
 }
 

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -10,3 +10,4 @@ disk=DISK
 [virtual-signal-name]
 signal-diskreader-read=DISK Read Command
 signal-diskreader-write=DISK Write Command
+signal-diskreader-status=DISK Reader Status


### PR DESCRIPTION
* Add fast-erase (R = -2); should probably be option-controlled, it might also appropriate for this to be the result of trying providing writesignal (W = -1) instead of (R = -2)
* Add signal-diskreader-status: an (awful?) way to get the physical state of the reader depending on the inputsignal given, returns one of:
** ERR_NO_DISK (-1) : no disk in drive, but tried to do something that needs a disk
** ERR_MACHINE_BLOCKED (-2) : can't eject because the outputslot is full
** DISK_OP_OK (1) : returned when eject (R = -1) or when erase (R = -2) are OK
** ERR_ILLEGAL_READ (-3) : returned when the readsignal is not a legal param ~(-1, -2, [1-512])
** ERR_ILLEGAL_WRITE (-4) : returned when the writesignal is not a legal param ~([1-512])
* Fix case where providing an eject signal with a disk in the outputslot (furnace_result) results in the slot being overwritten, destroying disk(s); right now this just checks if the outputslot is a disk and is valid -- if so it will prevent the eject -- but this should probably be widened to check if anything is in the outputslot
* The logic on this could be seriously tidied up: transition from `not hasDisk` -> `state = -1` could (should) be rearranged to make it less of an eyesore to read